### PR TITLE
Add pingproto-over-http helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go: 
+ - 1.9.1
+ - 1.10.3
+ - release
+ - tip

--- a/http.go
+++ b/http.go
@@ -62,7 +62,10 @@ func (r HTTPRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 // so, upgrades the connection. It's important to close the returned WriteCloser.
 func HTTPTryContentEncoding(
 	w http.ResponseWriter, r *http.Request,
-) io.WriteCloser {
+) (
+	wApplication io.WriteCloser,
+	upgraded bool,
+) {
 	if te := r.Header.Get("Accept-Encoding"); te != httpEncodingName {
 		// No upgrade.
 		return struct {
@@ -70,11 +73,11 @@ func HTTPTryContentEncoding(
 			nopCloser
 		}{
 			Writer: w,
-		}
+		}, false
 	}
 
 	w.Header().Set("Content-Εncoding", httpEncodingName)
-	return NewWriter(w)
+	return NewWriter(w), true
 }
 
 // isDecoder enables the tests to tell that a response has been unwrapped.

--- a/http.go
+++ b/http.go
@@ -1,0 +1,102 @@
+package pingproto
+
+import (
+	"io"
+	"net/http"
+)
+
+// NewHTTPClient constructs a HTTP client which understands the pingproto and
+// sends an Accept-Encoding: pingproto/1.0 header.
+// If wrapee is nil, defaults to http.DefaultClient.
+func NewHTTPClient(wrapee *http.Client) *http.Client {
+	if wrapee == nil {
+		wrapee = http.DefaultClient
+	}
+	wrapeeCopy := *wrapee
+	if wrapeeCopy.Transport == nil {
+		wrapeeCopy.Transport = http.DefaultTransport
+	}
+	wrapeeCopy.Transport = HTTPRoundTripper{wrapeeCopy.Transport}
+	return &wrapeeCopy
+}
+
+// HTTPRoundTripper does content negotiation through the Content-Εncoding
+// header, and transparently unwraps pingproto requests.
+type HTTPRoundTripper struct{ http.RoundTripper }
+
+const httpEncodingName = "pingproto/1.0"
+
+// RoundTrip implements the http.RoundTripper interface.
+func (r HTTPRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("Accept-Encoding", httpEncodingName)
+	resp, err := r.RoundTripper.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if te := resp.Header.Get("Content-Εncoding"); te != httpEncodingName {
+		return resp, err // Not a transfer encoding we recognize.
+	}
+
+	// Remove header, since the encoding is transparent to the client.
+	resp.Header.Del("Content-Εncoding")
+
+	rApp := NewReader(resp.Body) // unwrap pingproto
+
+	resp.Body = struct {
+		io.Reader
+		io.Closer
+		isDecoder // embedded here so that tests can tell.
+	}{
+		Reader: rApp,
+		Closer: composeClosers(
+			rApp,
+			io.Closer(resp.Body),
+		),
+	}
+
+	return resp, err
+}
+
+// HTTPTryContentEncoding determines if the client supports pingproto, and if
+// so, upgrades the connection. It's important to close the returned WriteCloser.
+func HTTPTryContentEncoding(
+	w http.ResponseWriter, r *http.Request,
+) io.WriteCloser {
+	if te := r.Header.Get("Accept-Encoding"); te != httpEncodingName {
+		// No upgrade.
+		return struct {
+			io.Writer
+			nopCloser
+		}{
+			Writer: w,
+		}
+	}
+
+	w.Header().Set("Content-Εncoding", httpEncodingName)
+	return NewWriter(w)
+}
+
+// isDecoder enables the tests to tell that a response has been unwrapped.
+type isDecoder interface{ private() }
+
+type nopCloser struct{}
+
+func (nopCloser) Close() error { return nil }
+
+func composeClosers(closers ...io.Closer) composeClosersImpl {
+	return composeClosersImpl{closers}
+}
+
+type composeClosersImpl struct{ closers []io.Closer }
+
+func (c composeClosersImpl) Close() error {
+	var err error
+	for _, closer := range c.closers {
+		err2 := closer.Close()
+		if err == nil { // first error is sticky.
+			err = err2
+		}
+	}
+	return err
+}

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,81 @@
+package pingproto
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPContentEncodingNegotiation(t *testing.T) {
+	s := httptest.NewServer(
+		http.HandlerFunc(func(wWire http.ResponseWriter, r *http.Request) {
+			wApp := HTTPTryContentEncoding(wWire, r)
+			defer wApp.Close()
+
+			// Has the effect of writing a ping if the upgrade has happened,
+			// otherwise NO-OP.
+			wApp.Write(nil)
+
+			io.WriteString(wApp, "Hello, world\n")
+		}))
+	defer s.Close()
+
+	doRequest := func(
+		t *testing.T,
+		c *http.Client,
+		shouldBeDecoder bool,
+	) {
+		pingTestMu.Lock()
+		defer pingTestMu.Unlock()
+
+		var nPings int
+		oldPingTestCallback := pingTestCallback
+		pingTestCallback = func() { nPings++ }
+		defer func() { pingTestCallback = oldPingTestCallback }()
+
+		resp, err := c.Get(s.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if _, ok := resp.Body.(isDecoder); ok != shouldBeDecoder {
+			if shouldBeDecoder {
+				t.Logf("resp.Body should be a decoder: %T", resp.Body)
+			} else {
+				t.Logf("resp.Body should not be a decoder: %T", resp.Body)
+			}
+		}
+
+		content, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal([]byte("Hello, world\n"), content) {
+			t.Fatalf("Unexpected content: %q", content)
+		}
+
+		if shouldBeDecoder {
+			if nPings < 1 { // expect at least one ping.
+				t.Logf("Missing pings: nPings < 1 : (%d < 1)", nPings)
+			}
+		} else {
+			if nPings != 0 {
+				t.Logf("Unexpected pings: nPings != 0 : (%d != 0)", nPings)
+			}
+		}
+	}
+
+	t.Run("withPingProtoClient", func(t *testing.T) {
+		c := NewHTTPClient(nil) // pingproto
+		doRequest(t, c, true)
+	})
+	t.Run("withPlainClient", func(t *testing.T) {
+		c := http.DefaultClient // not pingproto
+		doRequest(t, c, false)
+	})
+}


### PR DESCRIPTION
This PR adds a `pingproto.NewHTTPClient(wrapee *http.Client) *http.Client`
which automatically negotiates pingproto upgrades, and a server-side helper,
`HTTPTryContentEncoding(w, r) io.WriteCloser` which does the same on the server
side.